### PR TITLE
ASDPLNG-160: Address multiple identified issues

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -133,7 +133,6 @@ The following parameters are available in the `profile_update_os::yum_upgrade` c
 * [`config_file`](#config_file)
 * [`enabled`](#enabled)
 * [`excluded_packages`](#excluded_packages)
-* [`installonly_limit`](#installonly_limit)
 * [`random_delay`](#random_delay)
 * [`package`](#package)
 * [`service`](#service)
@@ -142,7 +141,6 @@ The following parameters are available in the `profile_update_os::yum_upgrade` c
 * [`update_minute`](#update_minute)
 * [`update_months`](#update_months)
 * [`update_week_of_month`](#update_week_of_month)
-* [`yum_config_file`](#yum_config_file)
 
 ##### <a name="command"></a>`command`
 
@@ -167,12 +165,6 @@ State of whether yum updates via cron are enabled
 Data type: `Array`
 
 List of packages to exclude from yum updates
-
-##### <a name="installonly_limit"></a>`installonly_limit`
-
-Data type: `Integer`
-
-Maximum number of versions that can be installed simultaneously for any single package
 
 ##### <a name="random_delay"></a>`random_delay`
 
@@ -227,12 +219,6 @@ Data type: `String`
 
 Week of the month for yum update cron, e.g. "1"-"5" or "any"
 If not defined cron runs every week
-
-##### <a name="yum_config_file"></a>`yum_config_file`
-
-Data type: `String`
-
-Full path to yum config file for the OS version
 
 ## Functions
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,7 +12,7 @@ profile_update_os::kernel_upgrade::update_week_of_month: ""
 profile_update_os::yum_upgrade::enabled: true
 profile_update_os::yum_upgrade::excluded_packages:
   - "kernel"
-profile_update_os::yum_upgrade::installonly_limit: 2
+  - "kernel*"
 profile_update_os::yum_upgrade::random_delay: 30
 profile_update_os::yum_upgrade::update_day_of_week: ""
 profile_update_os::yum_upgrade::update_hour: 5

--- a/manifests/kernel_upgrade.pp
+++ b/manifests/kernel_upgrade.pp
@@ -41,22 +41,18 @@ class profile_update_os::kernel_upgrade (
 
   if $enabled {
 
-    if ( ! empty($update_day_of_week) ) {
+    if empty($update_day_of_week) {
+      $day_of_week = profile_update_os::calculate_day_of_week($facts['hostname'])
+    } else {
       $day_of_week = $update_day_of_week
     }
-    else
-    {
-      $day_of_week = profile_update_os::calculate_day_of_week($facts['hostname'])
-    }
-    if ( ! empty($update_week_of_month) ) {
+    if empty($update_week_of_month) {
+      $week_num = profile_update_os::calculate_week_of_month($facts['hostname'])
+    } else {
       $week_num = $update_week_of_month
     }
-    else
-    {
-      $week_num = profile_update_os::calculate_week_of_month($facts['hostname'])
-    }
 
-    if ( empty($update_months) ) {
+    if empty($update_months) {
       $cron_update_months = '*'
       $motd_months = 'each month'
     } else {


### PR DESCRIPTION
Remove setting of yum installonly_limit - Fixes #3 
Enhance readability of cron day-of-week/day-of-month/month assignments - Fixes #4 
Add wall message to kernel_upgrade script if no reboot required - Fixes #6 
Add default yum exclude 'kernel*' - wildcard breaks use of puppet/yum module - Fixes #7 
Add wall messages to kernel_upgrade before each shutdown command - Fixes #9 