### PR TITLE
SVC-3240: Fix discovered issues related to installing openafs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -141,6 +141,7 @@ The following parameters are available in the `profile_update_os::yum_upgrade` c
 * [`update_minute`](#update_minute)
 * [`update_months`](#update_months)
 * [`update_week_of_month`](#update_week_of_month)
+* [`yum_config_file`](#yum_config_file)
 
 ##### <a name="command"></a>`command`
 
@@ -219,6 +220,12 @@ Data type: `String`
 
 Week of the month for yum update cron, e.g. "1"-"5" or "any"
 If not defined cron runs every week
+
+##### <a name="yum_config_file"></a>`yum_config_file`
+
+Data type: `String`
+
+Full path to yum config file for the OS version
 
 ## Functions
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,7 +12,8 @@ profile_update_os::kernel_upgrade::update_week_of_month: ""
 profile_update_os::yum_upgrade::enabled: true
 profile_update_os::yum_upgrade::excluded_packages:
   - "kernel"
-  - "kernel*"
+  - "kernel-core*"
+  - "kernel-modules*"
 profile_update_os::yum_upgrade::random_delay: 30
 profile_update_os::yum_upgrade::update_day_of_week: ""
 profile_update_os::yum_upgrade::update_hour: 5

--- a/manifests/yum_upgrade.pp
+++ b/manifests/yum_upgrade.pp
@@ -77,7 +77,15 @@ class profile_update_os::yum_upgrade (
 
     # PERHAPS SHOULD BE MOVED TO A DIFFERENT PROFILE CLASS
     # IS HERE TO MAKE SURE KERNEL PACKAGE EXCLUDED BY DEFAULT
-    if $excluded_packages {
+    if empty($excluded_packages) {
+      file_line { 'yum_config_exclude':
+        ensure            => 'absent',
+        #line              => 'exclude',
+        path              => $yum_config_file,
+        match             => '^exclude*',
+        match_for_absence => true,
+      }
+    } else {
       $excludes = join($excluded_packages, ' ')
 #      include ::yum
 #      yum::config { 'exclude': ensure => $excludes, }


### PR DESCRIPTION
Fix yum exclude if excluded_packages is empty
Fix default excluded packages for kernel packages

This is being tested on the following servers:
- `asd-test-centos7a`
- `asd-test-rhel8b`
- `users`
