### PR TITLE
Update for support of ncsa/profile_motd tag v0.1.1

### DIFF
--- a/manifests/kernel_upgrade.pp
+++ b/manifests/kernel_upgrade.pp
@@ -159,10 +159,7 @@ class profile_update_os::kernel_upgrade (
     $motdcontent = @("EOF")
       This system updates and reboots ${weeks} ${day}${month_prefix} ${motd_months} at ${hour}:${minute} ${::timezone}.
       | EOF
-    file { '/etc/motd.d':
-      ensure => 'directory',
-      mode   => '0755',
-    }
+    ensure_resource( 'file', '/etc/motd.d', { 'ensure' => 'directory', 'mode' => '0755', })
     file { '/etc/motd.d/kernel_upgrade':
       ensure  => file,
       mode    => '0644',


### PR DESCRIPTION
Change file /etc/motd.d to be an ensure resource to avoid duplicate declaration

This is to fix https://github.com/ncsa/puppet-profile_motd/issues/1

This is being tested on the following hosts:
- asd-test-centos7a
- asd-test-rhel8a