### PR TITLE
Apply fix from past commit to scheduled_reboot.pp

### DIFF
--- a/manifests/scheduled_reboot.pp
+++ b/manifests/scheduled_reboot.pp
@@ -47,35 +47,32 @@ class profile_update_os::scheduled_reboot (
       $motd_months = join( capitalize( $months_3char_abr ), '/' )
     }
 
-    cron { 'scheduled_reboot':
-      command => "( ${profile_update_os::root_cron_scripts_dir}/run-if-today.sh ${reboot_week_of_month} ${reboot_day_of_week} \
-&& ${command} )",
+    Cron {
       hour    => $reboot_hour,
       minute  => $reboot_minute,
       month   => $cron_reboot_months,
+      user    => 'root',
+      weekday => '*',
+    }
+
+    cron { 'scheduled_reboot':
+      command => "( ${profile_update_os::root_cron_scripts_dir}/run-if-today.sh ${reboot_week_of_month} ${reboot_day_of_week} \
+&& ${command} )",
     }
     $notice_of_reboot_text = "This server (${::fqdn}) will be rebooted in"
     cron { '48_hour_notice_of_reboot':
       command => "( ${profile_update_os::root_cron_scripts_dir}/run-if-today.sh ${reboot_week_of_month} ${reboot_day_of_week} 2 \
 && /usr/bin/wall -n '${notice_of_reboot_text} 48 hours.' )",
-      hour    => $reboot_hour,
-      minute  => $reboot_minute,
-      month   => $cron_reboot_months,
     }
     cron { '24_hour_notice_of_reboot':
       command => "( ${profile_update_os::root_cron_scripts_dir}/run-if-today.sh ${reboot_week_of_month} ${reboot_day_of_week} 1 \
 && /usr/bin/wall -n '${notice_of_reboot_text} 24 hours.' )",
-      hour    => $reboot_hour,
-      minute  => $reboot_minute,
-      month   => $cron_reboot_months,
     }
     $reboot_one_hour_earlier = $reboot_hour - 1
     cron { '1_hour_notice_of_reboot':
       command => "( ${profile_update_os::root_cron_scripts_dir}/run-if-today.sh ${reboot_week_of_month} ${reboot_day_of_week} \
 && /usr/bin/wall -n '${notice_of_reboot_text} 1 hour.' )",
       hour    => $reboot_one_hour_earlier,
-      minute  => $reboot_minute,
-      month   => $cron_reboot_months,
     }
 
     ## UPDATE MOTD


### PR DESCRIPTION
When setting up scheduled_reboot.pp I copied an old version of
kernel_upgrade.pp, which did not have the changes from the following
commit: 2c0af2a7f2c0e7a52b796f36fb03300ab829408f

Applying the changes from that commit to the scheduled_reboot class