### PR TITLE
Fix language of motd when set to ALL weeks

### DIFF
--- a/manifests/kernel_upgrade.pp
+++ b/manifests/kernel_upgrade.pp
@@ -178,8 +178,8 @@ ${reboot_option} ${updates_reboot_option} ${updates_today_option} ${reboot_pkgs_
         $month_prefix = ' of'
       }
       /any/: {
-        $weeks = 'all'
-        $month_prefix = 's of'
+        $weeks = 'each'
+        $month_prefix = ' of'
       }
       default: {
         $weeks = 'unknown'

--- a/manifests/scheduled_reboot.pp
+++ b/manifests/scheduled_reboot.pp
@@ -99,8 +99,8 @@ class profile_update_os::scheduled_reboot (
         $month_prefix = ' of'
       }
       /any/: {
-        $weeks = 'all'
-        $month_prefix = 's of'
+        $weeks = 'each'
+        $month_prefix = ' of'
       }
       default: {
         $weeks = 'unknown'


### PR DESCRIPTION
Change language for motd notice from:
```
This system reboots all Wednesdays of each month at 23:59 CDT.
```
to be:
```
This system reboots each Wednesday of each month at 23:59 CDT.
```