### PR TITLE
SVCPLAN-6915: Clarify reboot motd to specify the server and hostname …

### DIFF
--- a/manifests/scheduled_reboot.pp
+++ b/manifests/scheduled_reboot.pp
@@ -127,7 +127,7 @@ class profile_update_os::scheduled_reboot (
     }
 
     $motdcontent = @("EOF")
-      This system reboots ${weeks} ${day}${month_prefix} ${motd_months} at ${hour}:${minute} ${facts['timezone']}.
+      This server (${facts['networking']['hostname']}) reboots ${weeks} ${day}${month_prefix} ${motd_months} at ${hour}:${minute} ${facts['timezone']}.
       | EOF
 
     ensure_resource( 'file', '/etc/motd.d', { 'ensure' => 'directory', 'mode' => '0755', })


### PR DESCRIPTION
…that is rebooting

Fix #29 

This is being tested on `cc-login-test2`:
```
...
Success. Logging you in...
cc-login-test2.campuscluster.illinois.edu (141.142.112.25)
  OS: RedHat 9.4   HW: QEMU   CPU: 32x 2.75 GHz   RAM: 63 GB
  ▝▜▛▘    ╔═╗┌─┐┌┬┐┌─┐┬ ┬┌─┐   ╔═╗┬  ┬ ┬┌─┐┌┬┐┌─┐┬─┐
   ▐▌     ║  ├─┤│││├─┘│ │└─┐   ║  │  │ │└─┐ │ ├┤ ├┬┘
  ▗▟▙▖    ╚═╝┴ ┴┴ ┴┴  └─┘└─┘   ╚═╝┴─┘└─┘└─┘ ┴ └─┘┴└─
  Welcome to Campus Cluster @ University of Illinois

   User Guide: https://campuscluster.illinois.edu/user_info/doc/
      Support: help@campuscluster.illinois.edu

This server (cc-login-test2) reboots each Wednesday of each month at 03:00 CST.
Last login: Fri Jan 24 06:49:52 2025 from 172.29.128.24

Quota usage for user bglick:
...
```